### PR TITLE
Revert "21-add-option-to-revert-to-default-storage-state-on-serializer-parsing-error"

### DIFF
--- a/src/Options.ts
+++ b/src/Options.ts
@@ -7,7 +7,6 @@ export interface Options<T> {
 	storageType?: StorageType;
 	storageEventUpdatesStore?: boolean;
 	persistLazily?: boolean;
-	resetToDefaultOnParsingError?: boolean;
 }
 
 export interface RuntimeOptions<T> extends Required<Options<T>> {}

--- a/src/Serializer.ts
+++ b/src/Serializer.ts
@@ -1,4 +1,4 @@
 export interface Serializer<T> {
 	parse(text: string): T;
-	stringify(value: T): string;
+	stringify(object: T): string;
 }

--- a/src/SynchronisingRuntimeOptions.ts
+++ b/src/SynchronisingRuntimeOptions.ts
@@ -65,12 +65,4 @@ export class SynchronisingRuntimeOptions<T> implements RuntimeOptions<T> {
 	set persistLazily(value) {
 		this.runtimeOptions.persistLazily = value;
 	}
-
-	get resetToDefaultOnParsingError() {
-		return this.runtimeOptions.resetToDefaultOnParsingError;
-	}
-
-	set resetToDefaultOnParsingError(value) {
-		this.runtimeOptions.resetToDefaultOnParsingError = value;
-	}
 }

--- a/src/addDefaultsForMissingOptions.ts
+++ b/src/addDefaultsForMissingOptions.ts
@@ -6,7 +6,6 @@ const defaultOptions = {
 	storageType: StorageType.Local,
 	storageEventUpdatesStore: true,
 	persistLazily: false,
-	resetToDefaultOnParsingError: true,
 };
 
 export const addDefaultsForMissingOptions = <T>(options: Options<T>): RuntimeOptions<T> => ({

--- a/src/getSyncStoreWithBrowserStorage.ts
+++ b/src/getSyncStoreWithBrowserStorage.ts
@@ -11,23 +11,8 @@ export const getSyncStoreWithBrowserStorage = <T>(
 	const { getFromStorage, setToStorage } = storageManager;
 	const defaultStoreValue = get(store);
 
-	const resetToDefault = () => {
-		setToStorage(defaultStoreValue);
-		store.set(defaultStoreValue);
-	};
-
 	return () => {
-		let fromStorage;
-
-		try {
-			fromStorage = getFromStorage();
-		} catch (error) {
-			if (runtimeOptions.resetToDefaultOnParsingError) {
-				resetToDefault();
-			}
-
-			throw error;
-		}
+		const fromStorage = getFromStorage();
 
 		if (fromStorage !== undefined) {
 			store.set(fromStorage);
@@ -35,7 +20,8 @@ export const getSyncStoreWithBrowserStorage = <T>(
 		}
 
 		if (!runtimeOptions.persistLazily && defaultStoreValue !== undefined) {
-			resetToDefault();
+			setToStorage(defaultStoreValue);
+			store.set(defaultStoreValue);
 		}
 	};
 };

--- a/src/giveSvelteStorePersistenceBehaviour.ts
+++ b/src/giveSvelteStorePersistenceBehaviour.ts
@@ -34,12 +34,8 @@ export const giveSvelteStorePersistenceBehaviour = <T>(
 
 	const handleStorage = (event: StorageEvent) => {
 		if (event.key === runtimeOptions.storageKey) {
-			if (event.newValue != null) {
-				const valueToSet = runtimeOptions.serializer.parse(event.newValue);
-
-				if (runtimeOptions.storageEventUpdatesStore === true) {
-					set(valueToSet);
-				}
+			if (runtimeOptions.storageEventUpdatesStore === true && event.newValue != null) {
+				set(runtimeOptions.serializer.parse(event.newValue));
 			}
 		}
 	};

--- a/tests/infrastructure/testHarness/src/App.svelte
+++ b/tests/infrastructure/testHarness/src/App.svelte
@@ -31,6 +31,8 @@
 	function instantiateStore() {
 		const options = JSON.parse(optionsText ?? "{}") as OptionsWithoutStorageKey<string>;
 
+		console.log("GEEBLE", valueToInitialiseStoreWith);
+
 		store = giveSvelteStorePersistenceBehaviour(writable(valueToInitialiseStoreWith), {
 			storageKey,
 			...options,


### PR DESCRIPTION
Reverts drtrt-org/give-svelte-store-persistence-behaviour#22

I have decided that this is all getting too complicated. Instead, library consumers can use their own `parse` function by providing a `Serializer`. This `parse` can be wrapped with a try/catch and then the consumer has full control over what to return from the parse on-error, be that a default value or something else.